### PR TITLE
Switch rust docker build to use rust-opt from sbo.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,7 @@
       "fileMatch": [
         "^docker/imapfilter/build-imapfilter.sh$",
         "^docker/processor/build-jq.sh$",
-        "^docker/processor/build-rust16.sh$"
+        "^docker/processor/build-rust-opt.sh$"
       ],
       "matchStrings": [
         "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?_VERSION=\"(?<currentValue>.*)\""

--- a/docker/processor/Dockerfile
+++ b/docker/processor/Dockerfile
@@ -42,7 +42,7 @@ FROM base AS rust
 
 WORKDIR /tmp
 
-COPY docker/processor/build-rust16.sh .
+COPY docker/processor/build-rust-opt.sh .
 COPY processor processor
 
 # hadolint ignore=DL3003
@@ -54,8 +54,8 @@ RUN export TERSE=0 && slackpkg -default_answer=yes -batch=on update && \
     llvm-13 \
     pkg-config \
     && \
-    bash build-rust16.sh && rm build-rust16.sh && installpkg /tmp/rust16-* && rm -rf /tmp/rust16* && \
-    (cd processor && PATH="/opt/rust16/bin:$PATH" LD_LIBRARY_PATH="/opt/rust16/lib64" CARGO_HOME=.cargo cargo build --release && cp target/release/processor /tmp/processor-bin) && \
+    bash build-rust-opt.sh && rm build-rust-opt.sh && installpkg /tmp/rust-opt-* && rm -rf /tmp/rust-opt* && \
+    (cd processor && PATH="/opt/rust/bin:$PATH" LD_LIBRARY_PATH="/opt/rust/lib64" CARGO_HOME=.cargo cargo build --release && cp target/release/processor /tmp/processor-bin) && \
     rm -rf processor && mv /tmp/processor-bin /tmp/processor && \
     slackpkg -default_answer=yes -batch=on remove \
     binutils \
@@ -64,7 +64,7 @@ RUN export TERSE=0 && slackpkg -default_answer=yes -batch=on update && \
     llvm-13 \
     pkg-config \
     && rm -rf /var/cache/packages/* && rm -rf /var/lib/slackpkg/* && \
-    removepkg rust16 && \
+    removepkg rust-opt && \
     echo "Built"
 
 FROM base AS jq

--- a/docker/processor/build-rust-opt.sh
+++ b/docker/processor/build-rust-opt.sh
@@ -36,16 +36,16 @@ export PKGTYPE=txz
 (
   cd SlackBuildsOrg-slackbuilds-*
 
-  cd development/rust16
+  cd development/rust-opt
 
   # shellcheck source=/dev/null
-  . rust16.info
+  . rust-opt.info
 
   # shellcheck disable=SC2154
   wget "$DOWNLOAD_x86_64"
   # shellcheck disable=SC2154
   printf "%s\t%s\n" "$MD5SUM_x86_64" "$(basename "$DOWNLOAD_x86_64")" | md5sum --check --quiet
-  bash rust16.SlackBuild
+  bash rust-opt.SlackBuild
 )
 
 rm -rf SlackBuildsOrg-slackbuilds-*


### PR DESCRIPTION
The previous package rust16 will eventually be removed. rust-opt is the
replacement and basically follows upstream releases, but installed into
/opt.